### PR TITLE
Add two new events to the player class (tank & level)

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -4,6 +4,7 @@ import { game } from './game';
 import { arenaScaling } from './arena_scaling';
 import { playerMovement } from './player_movement';
 import { gamepad } from './diep_gamepad';
+import { CanvasKit } from './canvas_kit';
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve, reject) => setTimeout(resolve, ms));
 
@@ -13,6 +14,7 @@ class Player extends EventEmitter {
     #mouseScreenPos = new Vector(0, 0);
     #mousePos = new Vector(0, 0);
     #gamemode = window.localStorage.gamemode;
+    #level = 1;
 
     constructor() {
         super();
@@ -68,6 +70,19 @@ class Player extends EventEmitter {
                     return Reflect.apply(target, thisArg, args);
                 },
             });
+
+            //lvl event listener
+            CanvasKit.hook('fillText', (target, thisArg, args) => {
+                const text = args[0];
+                const match = text.match(/^Lvl (\d+) \w+/);
+                if (match == null) {
+                    return;
+                }
+
+                this.#level = Number(match[1]);
+
+                super.emit('level', this.#level);
+            });
         });
     }
 
@@ -89,6 +104,10 @@ class Player extends EventEmitter {
 
     get gamemode(): string {
         return this.#gamemode;
+    }
+
+    get level(): number {
+        return this.#level;
     }
 
     /**

--- a/src/player.ts
+++ b/src/player.ts
@@ -14,6 +14,7 @@ class Player extends EventEmitter {
     #mouseScreenPos = new Vector(0, 0);
     #mousePos = new Vector(0, 0);
     #gamemode = window.localStorage.gamemode;
+    #tank = 'Tank';
     #level = 1;
 
     constructor() {
@@ -71,17 +72,27 @@ class Player extends EventEmitter {
                 },
             });
 
-            //lvl event listener
+            // tank and level event listener
             CanvasKit.hook('fillText', (target, thisArg, args) => {
                 const text = args[0];
-                const match = text.match(/^Lvl (\d+) \w+/);
+                const match = text.match(/^Lvl (\d+) (\w*)$/);
                 if (match == null) {
                     return;
                 }
 
-                this.#level = Number(match[1]);
+                const newLevel = Number(match[1]);
+                const newTank = match[2];
 
-                super.emit('level', this.#level);
+                // make sure to trigger events for all levels in between.
+                while (newLevel > this.#level + 1) {
+                    super.emit('level', ++this.#level);
+                }
+
+                if (newLevel !== this.#level) super.emit('level', newLevel);
+                if (newTank !== this.#tank) super.emit('tank', newTank);
+
+                this.#level = newLevel;
+                this.#tank = match[2];
             });
         });
     }
@@ -108,6 +119,10 @@ class Player extends EventEmitter {
 
     get level(): number {
         return this.#level;
+    }
+
+    get tank(): string {
+        return this.#tank;
     }
 
     /**

--- a/src/player.ts
+++ b/src/player.ts
@@ -14,8 +14,8 @@ class Player extends EventEmitter {
     #mouseScreenPos = new Vector(0, 0);
     #mousePos = new Vector(0, 0);
     #gamemode = window.localStorage.gamemode;
-    #tank = 'Tank';
     #level = 1;
+    #tank = 'Tank';
 
     constructor() {
         super();


### PR DESCRIPTION
This PR closes #13 

Added:
- Event - "level": This event is triggered when the player level changes.
- Event - "tank": This event is triggered when the player tank changes.

Note:
When another player has his name as "Lvl x y" (e.g. Lvl 16 Sniper) those events will also trigger.