### PR TITLE
Movement.predictPos(time) now takes the time in ms as input

### DIFF
--- a/examples/entity_debug_tool.user.js
+++ b/examples/entity_debug_tool.user.js
@@ -8,10 +8,10 @@
 // @namespace    https://greasyfork.org/users/541070
 // @grant        none
 // ==/UserScript==
-'use strict';
 if (!window.diepAPI) return window.alert('Please install diepAPI to use this script');
 
 const { entityManager, game, arenaScaling, Vector, CanvasKit, player } = window.diepAPI;
+
 class EntityOverlay {
     #canvas;
     #ctx;
@@ -31,7 +31,7 @@ class EntityOverlay {
         this.#ctx.clearRect(0, 0, window.innerWidth, window.innerHeight);
         entityManager.entities.forEach((entity) => {
             const position = arenaScaling.toScreenPos(entity.position);
-            const futurePos = arenaScaling.toScreenPos(entity.predictPos(performance.now() + 1000));
+            const futurePos = arenaScaling.toScreenPos(entity.predictPos(1000));
             const dimensions = arenaScaling.toScreenUnits(
                 new Vector(2 * entity.extras.radius, 2 * entity.extras.radius)
             );

--- a/examples/farmer.user.js
+++ b/examples/farmer.user.js
@@ -25,9 +25,8 @@ game.on('frame', () => {
     const entity = entityManager.entities
         .filter((x) => x.type > 3 && x.type !== 9)
         .reduce((acc, x) => {
-            const now = performance.now();
-            const distAcc = Vector.distance(acc.predictPos(now), player.predictPos(now));
-            const distX = Vector.distance(x.predictPos(now), player.predictPos(now));
+            const distAcc = Vector.distance(acc.predictPos(now), player.predictPos(0));
+            const distX = Vector.distance(x.predictPos(now), player.predictPos(0));
 
             return distX < distAcc ? x : acc;
         });

--- a/src/entity_manager.ts
+++ b/src/entity_manager.ts
@@ -66,7 +66,7 @@ class EntityManager {
         let shortestDistance = Number.MAX_SAFE_INTEGER;
 
         this.#entities.forEach((x, i) => {
-            const distance = Vector.distance(x.predictPos(performance.now()), position);
+            const distance = Vector.distance(x.predictPos(0), position);
 
             if (distance < shortestDistance) {
                 shortestDistance = distance;

--- a/src/movement.ts
+++ b/src/movement.ts
@@ -24,11 +24,11 @@ export class Movement {
     }
 
     /**
-     * Predict where this object will be at given `time`
-     * @param time performance.now() time
+     * Predict where this object will be after `time`
+     * @param time The time in ms.
      */
     predictPos(time: number): Vector {
-        const duration = (time - this.#velocityLastNow) / 1000;
+        const duration = (time + performance.now() - this.#velocityLastNow) / 1000;
         return Vector.add(this.#position, Vector.scale(duration, this.#velocity));
     }
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -92,8 +92,8 @@ class Player extends EventEmitter {
     }
 
     /**
-     * Predict where this object will be at given `time`
-     * @param time performance.now() time
+     * Predict where this object will be after `time`
+     * @param time The time in ms
      */
     predictPos(time: number): Vector {
         return playerMovement.predictPos(time);

--- a/tools/entities_debug_tool.ts
+++ b/tools/entities_debug_tool.ts
@@ -24,7 +24,7 @@ class EntityOverlay {
         this.#ctx.clearRect(0, 0, window.innerWidth, window.innerHeight);
         entityManager.entities.forEach((entity) => {
             const position = arenaScaling.toScreenPos(entity.position);
-            const futurePos = arenaScaling.toScreenPos(entity.predictPos(performance.now() + 1000));
+            const futurePos = arenaScaling.toScreenPos(entity.predictPos(1000));
             const dimensions = arenaScaling.toScreenUnits(
                 new Vector(2 * entity.extras.radius, 2 * entity.extras.radius)
             );


### PR DESCRIPTION
This is a breaking change and will make it easier and more intuitiv to use `Movement.predictPos(time)` method.

Before:
`Movement.predictPos(performance.now() + 1000)`

Now:
`Movement.predictPos(1000)`