### PR TITLE
Feature/fix retina display issue

### DIFF
--- a/examples/entity_debug_tool.user.js
+++ b/examples/entity_debug_tool.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Entity Debug Tool
 // @description  https://github.com/Cazka/diepAPI
-// @version      1.0.0
+// @version      1.0.1
 // @author       Cazka
 // @match        https://diep.io/*
 // @icon         https://www.google.com/s2/favicons?domain=diep.io
@@ -10,7 +10,7 @@
 // ==/UserScript==
 if (!window.diepAPI) return window.alert('Please install diepAPI to use this script');
 
-const { entityManager, game, arenaScaling, Vector, CanvasKit, player } = window.diepAPI;
+const { entityManager, game, arenaScaling, Vector, CanvasKit } = window.diepAPI;
 
 class EntityOverlay {
     #canvas;
@@ -24,15 +24,15 @@ class EntityOverlay {
         this.#onResize();
     }
     #onResize() {
-        this.#canvas.width = window.innerWidth;
-        this.#canvas.height = window.innerHeight;
+        this.#canvas.width = window.innerWidth * window.devicePixelRatio;
+        this.#canvas.height = window.innerHeight * window.devicePixelRatio;
     }
     #onFrame() {
-        this.#ctx.clearRect(0, 0, window.innerWidth, window.innerHeight);
+        this.#ctx.clearRect(0, 0, this.#canvas.width, this.#canvas.height);
         entityManager.entities.forEach((entity) => {
-            const position = arenaScaling.toScreenPos(entity.position);
-            const futurePos = arenaScaling.toScreenPos(entity.predictPos(1000));
-            const dimensions = arenaScaling.toScreenUnits(
+            const position = arenaScaling.toCanvasPos(entity.position);
+            const futurePos = arenaScaling.toCanvasPos(entity.predictPos(1000));
+            const dimensions = arenaScaling.toCanvasUnits(
                 new Vector(2 * entity.extras.radius, 2 * entity.extras.radius)
             );
             this.#ctx.strokeStyle = 9 === entity.type ? '#ffffff' : entity.extras.color;
@@ -51,7 +51,7 @@ class EntityOverlay {
             this.#ctx.lineTo(futurePos.x, futurePos.y);
             this.#ctx.stroke();
             //Time alive + id
-            const fontSize = arenaScaling.toScreenUnits(new Vector(30, 30));
+            const fontSize = arenaScaling.toCanvasUnits(new Vector(30, 30));
             this.#ctx.font = fontSize.x + 'px Ubuntu';
             this.#ctx.fillText(
                 `${entity.extras.id} ${Math.floor((performance.now() - entity.extras.timestamp) / 1000)}`,

--- a/examples/farmer.user.js
+++ b/examples/farmer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Farm Script
 // @description  press P to start the farmer
-// @version      0.0.5
+// @version      0.0.6
 // @author       Cazka
 // @match        https://diep.io/*
 // @icon         https://www.google.com/s2/favicons?domain=diep.io
@@ -22,14 +22,17 @@ window.addEventListener('keydown', (e) => {
 
 game.on('frame', () => {
     if (!farmActive) return;
-    const entity = entityManager.entities
-        .filter((x) => x.type > 3 && x.type !== 9)
-        .reduce((acc, x) => {
-            const now = performance.now();
-            const distAcc = Vector.distance(acc.predictPos(now), player.predictPos(0));
-            const distX = Vector.distance(x.predictPos(now), player.predictPos(0));
+    const entities = entityManager.entities.filter((x) => x.type > 3 && x.type !== 9);
 
-            return distX < distAcc ? x : acc;
-        });
+    if (entities.length === 0) {
+        return;
+    }
+
+    const entity = entities.reduce((acc, x) => {
+        const distAcc = Vector.distance(acc.predictPos(100), player.predictPos(100));
+        const distX = Vector.distance(x.predictPos(100), player.predictPos(100));
+
+        return distX < distAcc ? x : acc;
+    });
     if (entity) player.lookAt(entity.position);
 });

--- a/src/arena.ts
+++ b/src/arena.ts
@@ -9,7 +9,10 @@ class Arena {
     constructor() {
         game.on('frame', () => {
             const ratio = Vector.divide(minimap.minimapDim, minimap.viewportDim);
-            const arenaDim = Vector.multiply(ratio, new Vector(window.innerWidth, window.innerHeight));
+            const arenaDim = Vector.multiply(
+                ratio,
+                arenaScaling.screenToCanvas(new Vector(window.innerWidth, window.innerHeight))
+            );
             const arenaSize = Vector.round(arenaScaling.toArenaUnits(arenaDim));
             this.#size = arenaSize.x;
         });

--- a/src/arena_scaling.ts
+++ b/src/arena_scaling.ts
@@ -1,6 +1,5 @@
 import { Vector } from './vector';
 import { CanvasKit } from './canvas_kit';
-import { playerMovement } from './player_movement';
 import { camera } from './camera';
 
 class ArenaScaling {
@@ -28,7 +27,7 @@ class ArenaScaling {
 
     /**
      *
-     * @param {Vector} v The vector in screen units
+     * @param {Vector} v The vector in canvas units
      * @returns {Vector} The vector in arena units
      */
     toArenaUnits(v: Vector): Vector {
@@ -38,19 +37,22 @@ class ArenaScaling {
     /**
      *
      * @param {Vector} v The vector in arena units
-     * @returns {Vector} The vector in screen units
+     * @returns {Vector} The vector in canvas units
      */
-    toScreenUnits(v: Vector): Vector {
+    toCanvasUnits(v: Vector): Vector {
         return Vector.scale(this.#scalingFactor, v);
     }
 
     /**
      * Will translate coordinates from canvas to arena
-     * @param {Vector} screenPos The canvas coordinates
-     * @returns {Vector} The `screenPos` translated to arena coordinates
+     * @param {Vector} canvasPos The canvas coordinates
+     * @returns {Vector} The `canvasPos` translated to arena coordinates
      */
-    toArenaPos(screenPos: Vector): Vector {
-        const direction = Vector.subtract(screenPos, new Vector(window.innerWidth / 2, window.innerHeight / 2));
+    toArenaPos(canvasPos: Vector): Vector {
+        const direction = Vector.subtract(
+            canvasPos,
+            this.screenToCanvas(new Vector(window.innerWidth / 2, window.innerHeight / 2))
+        );
         const scaled = this.toArenaUnits(direction);
         const arenaPos = Vector.add(scaled, camera.position);
 
@@ -62,12 +64,41 @@ class ArenaScaling {
      * @param {Vector} arenaPos The arena coordinates
      * @returns {Vector} The `arenaPos` translated to canvas coordinates
      */
-    toScreenPos(arenaPos: Vector): Vector {
+    toCanvasPos(arenaPos: Vector): Vector {
         const direction = Vector.subtract(arenaPos, camera.position);
-        const scaled = this.toScreenUnits(direction);
-        const screenPos = Vector.add(scaled, new Vector(window.innerWidth / 2, window.innerHeight / 2));
+        const scaled = this.toCanvasUnits(direction);
+        const canvasPos = Vector.add(
+            scaled,
+            this.screenToCanvas(new Vector(window.innerWidth / 2, window.innerHeight / 2))
+        );
 
-        return screenPos;
+        return canvasPos;
+    }
+
+    screenToCanvasUnits(n: number) {
+        return n * window.devicePixelRatio;
+    }
+
+    canvasToScreenUnits(n: number) {
+        return n / window.devicePixelRatio;
+    }
+
+    /**
+     * Will translate coordinates from screen to canvas
+     * @param v The screen coordinates
+     * @returns The canvas coordinates
+     */
+    screenToCanvas(v: Vector) {
+        return Vector.scale(window.devicePixelRatio, v);
+    }
+
+    /**
+     * Will translate coordinates from canvas to screen
+     * @param v The canvas coordinates
+     * @returns the screen coordinates
+     */
+    canvasToScreen(v: Vector) {
+        return Vector.scale(1 / window.devicePixelRatio, v);
     }
 }
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -32,7 +32,7 @@ class Player extends EventEmitter {
             });
             //update mouse position
             game.on('frame', () => {
-                this.#mousePos = arenaScaling.toArenaPos(this.#mouseScreenPos);
+                this.#mousePos = arenaScaling.toArenaPos(arenaScaling.screenToCanvas(this.#mouseScreenPos));
             });
 
             //Mouse events
@@ -216,8 +216,8 @@ class Player extends EventEmitter {
         index -= 1;
         const x_index = index % 2;
         const y_index = Math.floor(index / 2);
-        const x = window.devicePixelRatio * arenaScaling.windowRatio * (x_index * 115 + 97.5);
-        const y = window.devicePixelRatio * arenaScaling.windowRatio * (y_index * 110 + 120);
+        const x = arenaScaling.screenToCanvasUnits(arenaScaling.windowRatio * (x_index * 115 + 97.5));
+        const y = arenaScaling.screenToCanvasUnits(arenaScaling.windowRatio * (y_index * 110 + 120));
 
         this.#mouseLock = true;
         window.input.mouse(x, y);
@@ -273,7 +273,7 @@ class Player extends EventEmitter {
     }
 
     lookAt(arenaPos: Vector): void {
-        const position = arenaScaling.toScreenPos(arenaPos);
+        const position = arenaScaling.toCanvasPos(arenaPos);
         window.input.mouse(position.x, position.y);
 
         this.#onmousemove({ clientX: position.x, clientY: position.y } as MouseEvent);
@@ -283,7 +283,7 @@ class Player extends EventEmitter {
         this.#mouseScreenPos = new Vector(e.clientX, e.clientY);
 
         if (gamepad.connected) {
-            const arenaPos = arenaScaling.toArenaPos(this.#mouseScreenPos);
+            const arenaPos = arenaScaling.toArenaPos(arenaScaling.screenToCanvas(this.#mouseScreenPos));
             const direction = Vector.subtract(arenaPos, this.position);
             let axes = Vector.scale(arenaScaling.fov / 1200 / 1.1, direction);
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -11,7 +11,7 @@ const sleep = (ms: number): Promise<void> => new Promise((resolve, reject) => se
 class Player extends EventEmitter {
     #isDead = true;
     #mouseLock = false;
-    #mouseScreenPos = new Vector(0, 0);
+    #mouseCanvasPos = new Vector(0, 0);
     #mousePos = new Vector(0, 0);
     #gamemode = window.localStorage.gamemode;
     #level = 1;
@@ -32,7 +32,7 @@ class Player extends EventEmitter {
             });
             //update mouse position
             game.on('frame', () => {
-                this.#mousePos = arenaScaling.toArenaPos(arenaScaling.screenToCanvas(this.#mouseScreenPos));
+                this.#mousePos = arenaScaling.toArenaPos(this.#mouseCanvasPos);
             });
 
             //Mouse events
@@ -280,10 +280,10 @@ class Player extends EventEmitter {
     }
 
     #onmousemove(e: MouseEvent): void {
-        this.#mouseScreenPos = new Vector(e.clientX, e.clientY);
+        this.#mouseCanvasPos = arenaScaling.screenToCanvas(new Vector(e.clientX, e.clientY));
 
         if (gamepad.connected) {
-            const arenaPos = arenaScaling.toArenaPos(arenaScaling.screenToCanvas(this.#mouseScreenPos));
+            const arenaPos = arenaScaling.toArenaPos(this.#mouseCanvasPos);
             const direction = Vector.subtract(arenaPos, this.position);
             let axes = Vector.scale(arenaScaling.fov / 1200 / 1.1, direction);
 

--- a/tools/entities_debug_tool.ts
+++ b/tools/entities_debug_tool.ts
@@ -1,4 +1,4 @@
-import { entityManager, game, arenaScaling, Vector, CanvasKit, player } from 'index';
+import { entityManager, game, arenaScaling, Vector, CanvasKit } from 'index';
 
 class EntityOverlay {
     #canvas: HTMLCanvasElement;
@@ -16,16 +16,16 @@ class EntityOverlay {
     }
 
     #onResize(): void {
-        this.#canvas.width = window.innerWidth;
-        this.#canvas.height = window.innerHeight;
+        this.#canvas.width = window.innerWidth * window.devicePixelRatio;
+        this.#canvas.height = window.innerHeight * window.devicePixelRatio;
     }
 
     #onFrame() {
-        this.#ctx.clearRect(0, 0, window.innerWidth, window.innerHeight);
+        this.#ctx.clearRect(0, 0, this.#canvas.width, this.#canvas.height);
         entityManager.entities.forEach((entity) => {
-            const position = arenaScaling.toScreenPos(entity.position);
-            const futurePos = arenaScaling.toScreenPos(entity.predictPos(1000));
-            const dimensions = arenaScaling.toScreenUnits(
+            const position = arenaScaling.toCanvasPos(entity.position);
+            const futurePos = arenaScaling.toCanvasPos(entity.predictPos(1000));
+            const dimensions = arenaScaling.toCanvasUnits(
                 new Vector(2 * entity.extras.radius, 2 * entity.extras.radius)
             );
             this.#ctx.strokeStyle = 9 === entity.type ? '#ffffff' : entity.extras.color;
@@ -46,7 +46,7 @@ class EntityOverlay {
             this.#ctx.stroke();
 
             //Time alive + id
-            const fontSize = arenaScaling.toScreenUnits(new Vector(30, 30));
+            const fontSize = arenaScaling.toCanvasUnits(new Vector(30, 30));
             this.#ctx.font = fontSize.x + 'px Ubuntu';
             this.#ctx.fillText(
                 `${entity.extras.id} ${Math.floor((performance.now() - entity.extras.timestamp) / 1000)}`,


### PR DESCRIPTION
This PR closes #21 

Finally there is support for retina displays or displays with a `window.devicePixelRatio != 1`.
If you are a Mac user this will make you very happy!

There are breaking changes to the API:

`arenaScaling.toScreenPos()` got renamed to `arenaScaling.toCanvasPos()`

`arenaScaling.toScreenUnits()` got renamed to `arenaScaling.toCanvasUnits()`

The name changes were necessary since there is now a difference between canvas pixels and screen pixels.